### PR TITLE
Rename `handleFoo` to `foo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ _EasyDL_ makes it easy to **download multiple files** in Swift.
 ```swift
 let downloader = Downloader(items: [(url1, file1), (url2, file2)])
 
-downloader.handleProgress { bytesDownloaded, bytesExpectedToDownload in
+downloader.progress { bytesDownloaded, bytesExpectedToDownload in
     print("\(bytesDownloaded) / \(bytesExpectedToDownload!)")
 }
 
-downloader.handleCompletion { result in
+downloader.completion { result in
     switch result {
     case .success:
         let data1 = try! Data(contentsOf: URL(fileURLWithPath: file1))
@@ -43,22 +43,22 @@ let downloader = Downloader(items: [item1, item2, item3])
 
 ## Flexible progress handling
 
-Following three overloads of `handleProgress` are available.
+Following three overloads of `progress` are available.
 
 ```swift
-downloader.handleProgress { (bytesDownloaded: Int64, bytesExpectedToDownload: Int64?) in
+downloader.progress { (bytesDownloaded: Int64, bytesExpectedToDownload: Int64?) in
     print("\(bytesDownloaded) / \(bytesExpectedToDownload!)")
 }
 ```
 
 ```swift
-downloader.handleProgress { (rate: Float?) in
+downloader.progress { (rate: Float?) in
     print("\(rate!) / 1.0")
 }
 ```
 
 ```swift
-downloader.handleProgress { (
+downloader.progress { (
     bytesDownloaded: Int64,
     bytesExpectedToDownload: Int64?,
     currentItemIndex: Int,
@@ -75,7 +75,7 @@ Also precise progress or non-precise progress can be designated.
 let downloader = Downloader(items: [(url1, file1), (url2, file2)], needsPreciseProgress: false)
 ```
 
-Usually, a `Downloader` gets sizes of the `Item`s by sending HEAD requests and summing up `Content-Length`s in the response headers before starting downloads. When `needsPreciseProgress` is `false`, a `Downloader` omits those HEAD request. Then `handleProgress` for `Float?` calls a callback with pseudo progress, which is calculated on the assumption that all `Item`s has a same size. That is, the amout of the progress for one `Item` is `1.0 / Float(items.count)`.
+Usually, a `Downloader` gets sizes of the `Item`s by sending HEAD requests and summing up `Content-Length`s in the response headers before starting downloads. When `needsPreciseProgress` is `false`, a `Downloader` omits those HEAD request. Then `progress` for `Float?` calls a callback with pseudo progress, which is calculated on the assumption that all `Item`s has a same size. That is, the amout of the progress for one `Item` is `1.0 / Float(items.count)`.
 
 ## Installation
 

--- a/Sources/EasyDL.swift
+++ b/Sources/EasyDL.swift
@@ -241,7 +241,7 @@ public class Downloader {
         }
     }
     
-    public func handleProgress(_ handler: @escaping (Int64, Int64?, Int, Int64, Int64?) -> ()) {
+    public func progress(_ handler: @escaping (Int64, Int64?, Int, Int64, Int64?) -> ()) {
         DispatchQueue.main.async { [weak self] in
             if let zelf = self, let bytesDownloaded = zelf.bytesDownloaded {
                 handler(bytesDownloaded, zelf.bytesExpectedToDownload, zelf.items.count, zelf.bytesDownloadedForItem, zelf.bytesExpectedToDownloadForItem)
@@ -254,7 +254,7 @@ public class Downloader {
         }
     }
     
-    public func handleCompletion(_ handler: @escaping (Result) -> ()) {
+    public func completion(_ handler: @escaping (Result) -> ()) {
         DispatchQueue.main.async {
             if let result = self.result {
                 handler(result)

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -15,19 +15,19 @@ extension Downloader {
         )
     }
 
-    public func handleProgress(_ handler: @escaping (Int64, Int64?) -> ()) {
-        handleProgress { done, whole, _, _, _ in
+    public func progress(_ handler: @escaping (Int64, Int64?) -> ()) {
+        progress { done, whole, _, _, _ in
             handler(done, whole)
         }
     }
     
-    public func handleProgress(_ handler: @escaping (Float?) -> ()) {
+    public func progress(_ handler: @escaping (Float?) -> ()) {
         if needsPreciseProgress {
-            handleProgress { done, whole in
+            progress { done, whole in
                 handler(whole.map { whole in Float(Double(done) / Double(whole)) })
             }
         } else {
-            handleProgress { _, _, itemIndex, done, whole in
+            progress { _, _, itemIndex, done, whole in
                 handler(whole.map { whole in (Float(itemIndex) + Float(Double(done) / Double(whole))) / Float(self.items.count) })
             }
         }

--- a/Tests/EasyDLTests/EasyDLTests.swift
+++ b/Tests/EasyDLTests/EasyDLTests.swift
@@ -21,12 +21,12 @@ class EasyDLTests: XCTestCase {
         /**/ let expectation = self.expectation(description: "")
         
         /**/ var progressSet: Set<String> = []
-        downloader.handleProgress { bytesDownloaded, bytesExpectedToDownload in
+        downloader.progress { bytesDownloaded, bytesExpectedToDownload in
             print("\(bytesDownloaded) / \(bytesExpectedToDownload!)")
             /**/ progressSet.insert("\(bytesDownloaded) / \(bytesExpectedToDownload!)")
         }
         
-        downloader.handleCompletion { result in
+        downloader.completion { result in
             switch result {
             case .success:
                 let data1 = try! Data(contentsOf: URL(fileURLWithPath: file1))
@@ -68,12 +68,12 @@ class EasyDLTests: XCTestCase {
         let expectation = self.expectation(description: "")
         
         var progressSet: Set<String> = []
-        downloader.handleProgress { (rate: Float?) in
+        downloader.progress { (rate: Float?) in
             print("\(rate!) / 1.0")
             progressSet.insert("\(rate!) / 1.0")
         }
         
-        downloader.handleCompletion { result in
+        downloader.completion { result in
             switch result {
             case .success:
                 let data1 = try! Data(contentsOf: URL(fileURLWithPath: file1))
@@ -141,12 +141,12 @@ class EasyDLTests: XCTestCase {
             let expectation = self.expectation(description: "")
             
             var progressSet: Set<String> = []
-            downloader.handleProgress { bytesDownloaded, bytesExpectedToDownload in
+            downloader.progress { bytesDownloaded, bytesExpectedToDownload in
                 print("\(bytesDownloaded) / \(bytesExpectedToDownload!)")
                 progressSet.insert("\(bytesDownloaded) / \(bytesExpectedToDownload!)")
             }
             
-            downloader.handleCompletion { result in
+            downloader.completion { result in
                 switch result {
                 case .success:
                     let data1 = try! Data(contentsOf: URL(fileURLWithPath: file1))
@@ -210,11 +210,11 @@ class EasyDLTests: XCTestCase {
         
         let expectation = self.expectation(description: "")
         
-        downloader.handleProgress { bytesDownloaded, bytesExpectedToDownload in
+        downloader.progress { bytesDownloaded, bytesExpectedToDownload in
             print("\(bytesDownloaded) / \(bytesExpectedToDownload!)")
         }
 
-        downloader.handleCompletion { result in
+        downloader.completion { result in
             switch result {
             case .success:
                 XCTFail()


### PR DESCRIPTION
`handleCompletion` and `handleProgress` receive a callback. It is equivalent to returning a `Promise` value. Then `completion` and `progress` seem more natural.