### PR TITLE
Make `ResponseError.response` public

### DIFF
--- a/Sources/EasyDL.swift
+++ b/Sources/EasyDL.swift
@@ -301,7 +301,7 @@ public class Downloader {
     }
     
     public struct ResponseError: Error {
-        let response: URLResponse
+        public let response: URLResponse
     }
     
     private enum ContentLengthResult {


### PR DESCRIPTION
It had been unintentionally `internal`.