### PR TITLE
最小iOSバージョンを12にする

### DIFF
--- a/EasyDL.xcodeproj/project.pbxproj
+++ b/EasyDL.xcodeproj/project.pbxproj
@@ -688,6 +688,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/EasyDL/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.EasyDL;
 				PRODUCT_NAME = EasyDL;
@@ -707,6 +708,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/EasyDL/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.koherent.EasyDL;
 				PRODUCT_NAME = EasyDL;


### PR DESCRIPTION
Xcode 15.2 で`EasyDL.xcodeproj` を開いてビルドしようとすると、下記エラーが出ます。

```
SDK does not contain 'libarclite' at the path '/Applications/Xcode15.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_iphoneos.a'; try increasing the minimum deployment target
```

これは最小iOSバージョンが9.0未満で生じる問題のようです。

<img width="1512" alt="スクリーンショット 2024-03-04 14 29 19" src="https://github.com/koher/easy-dl/assets/312792/9e3ecfcb-fdd9-4322-86f0-d5d6af7e0a0b">

また同時に以下の警告が出ます。

```
/Users/omochi/qoncept/areader/areader-ios/Modules/EasyDL/EasyDL.xcodeproj: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 12.0 to 17.2.99.
```

そこでこのパッチでは、
最小iOSバージョンを12.0に変更します。
